### PR TITLE
Fix collapsed sidebar padding.

### DIFF
--- a/sass/base/_layout.scss
+++ b/sass/base/_layout.scss
@@ -25,7 +25,6 @@ $header-padding-bottom: 1.5em !default;
   width: auto;
   clear: left;
   margin: 0;
-  padding: 2em 5px;
   // background-color: lighten($sidebar-bg, 2);
   section {
     &.odd, &.even { float: left; width: 48%; }
@@ -47,7 +46,7 @@ body {
   max-width: $max-width;
   position: relative;
   margin: 0 auto;
-  > header, > nav, > footer, #content > article, #content > div > article, #content > div > section {
+  > header, > nav, > footer, #content > article, #content > div > article, #content > div > section, &.collapse-sidebar aside.sidebar {
     @extend .group;
     padding-left: $pad-min;
     padding-right: $pad-min;
@@ -111,9 +110,6 @@ aside.sidebar {
 .toggle-sidebar { &, .no-sidebar & { display: none; }}
 
 body.sidebar-footer {
-  @media only screen and (min-width: 750px) {
-    aside.sidebar{ @include collapse-sidebar; }
-  }
   #content { margin-right: 0px; }
   .toggle-sidebar { display: none; }
 }
@@ -175,9 +171,6 @@ body.sidebar-footer {
   }
   aside.sidebar {
     width: $sidebar-width-wide - $sidebar-pad-wide*2;
-    .collapse-sidebar & {
-      padding: { left: $pad-wide; right: $pad-wide; }
-    }
   }
 }
 


### PR DESCRIPTION
Hi Alex,

We were encountering some strange behaviors with the collapsed sidebar. First, let me explain the desired sidebar behavior back to you and see if I understand it correctly:

There are two body classes of importance when dealing with the collapsed sidebar:
- `collapse-sidebar`: Indicates that the sidebar is currently collapsed, meaning that it is now shown in the footer and not on the right side. This can happen when the page is sized or resized to a smaller width, by clicking the sidebar toggler, or by setting `sidebar: collapse` in the config file.
- `sidebar-footer`: Indicates that the sidebar should be permanently shown in the footer. The sidebar toggler does not appear.

Now here are the behaviors that I was seeing:
- Width ≥ 992px
  - If the sidebar is collapsed by the toggler or resizing, the collapsed sidebar padding matches the content and looks great.
  - If the sidebar is collapsed by `sidebar: collapse` in the config file (which sets `sidebar-footer` on the body), the collapsed sidebar has no padding.
- Width < 992px
  - Whatever way it is collapsed, the sidebar shows no padding.

There are two problems that I see:
- The collapsed sidebar's behavior is not consistent across different ways to set it (toggler, resizing, config file). This seems to me a bug for sure.
- The collapsed sidebar's padding does not match the content. Personally, I like the sidebar's padding to match the content, but styles are subjective and I'm not exactly sure what was intended.

This PR fixes both. Let me know if that is not your preference. By the way, I tested this with a default Octopress master branch, not just with our site.

Sorry this got a little long. Took me a while to figure out and I wanted to explain it clearly.
